### PR TITLE
Use callPackage and flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,57 +2,57 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750005367,
-        "narHash": "sha256-h/aac1dGLhS3qpaD2aZt25NdKY7b+JT0ZIP2WuGsJMU=",
+        "lastModified": 1748026580,
+        "narHash": "sha256-rWtXrcIzU5wm/C8F9LWvUfBGu5U5E7cFzPYT1pHIJaQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c64dabd3aa85e0c02ef1cdcb6e1213de64baee3",
+        "rev": "11cb3517b3af6af300dd6c055aeda73c9bf52c48",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "25.05",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "parts": "parts"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,80 +4,31 @@
   description = "An exascale-capable cellular automaton for nucleation and grain growth";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    utils.url   = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/25.05";
+    parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = inputs @ { self, utils, ... }: utils.lib.eachDefaultSystem (system: rec {
-    config = rec {
-      pkgs = import inputs.nixpkgs {
-        inherit system;        
-        config.cudaSupport = true;
-        config.allowUnfree = true;
-      };
-    };
-
-    exaca = { src, version}: with config; pkgs.stdenv.mkDerivation {
-      pname = "exaca";
-      inherit version;
-      inherit src;
-
-      CMAKE_TLS_VERIFY=0;
-      
-      nativeBuildInputs = [
-        pkgs.cmake
+  outputs = inputs @ { self, parts, ... }: (
+    parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
       ];
 
-      buildInputs = [
-        pkgs.kokkos
-        pkgs.openmpi
-      ];
+      perSystem = { pkgs, ... }: {
+        packages = rec {
+          default = exaca;
 
-      propagatedBuildInputs = [
-        pkgs.openmpi
-      ];
-    };
-
-    packages = with config; rec {
-      default = exaca {
-        src = self;
-        version = self.shortRev or self.dirtyShortRev;
-      };
-
-      stable = exaca (rec {
-        src = pkgs.fetchFromGitHub {
-          owner = "LLNL";
-          repo  = "ExaCA";
-          rev   = "${version}";
-          hash  = "sha256-X21yP+sqxR/iM/4N/qKucB2hMmBLf00bVtlCS0QGVQw=";
+          exaca = pkgs.callPackage ./nix/exaca.nix {
+            src = self;
+            version = "master";
+          };
         };
-        version = "2.0.2";
-      });
-      
-    };
 
-    devShells = with config; rec {
-      default = exacaDev;
-
-      exacaDev = pkgs.mkShell rec {
-        name = "exaca-dev";
-
-        packages = with pkgs; [
-          git
-          clang-tools
-        ] ++ self.outputs.packages.${system}.default.buildInputs
-          ++ self.outputs.packages.${system}.default.nativeBuildInputs
-          ++ self.outputs.packages.${system}.default.propagatedBuildInputs
-          ++ pkgs.lib.optionals (pkgs.stdenv.hostPlatform.isLinux) [gdb cntr];
-
-        # Ensure the locales point at the correct archive location.
-        LOCALE_ARCHIVE = pkgs.lib.optional (pkgs.stdenv.hostPlatform.isLinux) (
-          "${pkgs.glibcLocales}/lib/locale/locale-archive"
-        );
-        
+        imports = [
+          ./nix/dev.nix
+        ];
       };
-    };
-    
-  });
-
+    }
+  );
 }

--- a/nix/NIX.md
+++ b/nix/NIX.md
@@ -13,10 +13,10 @@ To get a shell with ExaCA temporarily installed, run:
 To install this permanently, run:
 
     $ nix profile install github:LLNL/ExaCA
-	
-To get the latest stable release, use:
 
-    $ nix shell github:LLNL/ExaCA#stable
+To get a specific release, use:
+
+    $ nix shell github:LLNL/ExaCA/<tag>
 
 To build from a working copy use `nix develop` and run CMake manually:
 

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -1,0 +1,27 @@
+{ self', pkgs, lib, ... }:
+
+{
+  devShells = rec {
+    default = exacaDev;
+
+    exacaDev = pkgs.mkShell {
+      name = "exaca-dev";
+
+      packages = with pkgs; [
+        git
+        clang-tools
+      ] ++ lib.optionals (pkgs.stdenv.hostPlatform.isLinux) [
+        gdb
+      ];
+
+      inputsFrom = [
+        self'.packages.default
+      ];
+
+      # Ensure the locales point at the correct archive location.
+      LOCALE_ARCHIVE = lib.optional (pkgs.stdenv.hostPlatform.isLinux) (
+        "${pkgs.glibcLocales}/lib/locale/locale-archive"
+      );
+    };
+  };
+}

--- a/nix/exaca.nix
+++ b/nix/exaca.nix
@@ -1,0 +1,34 @@
+{
+  src, version,
+
+  lib, stdenv,
+
+  cmake,
+
+  kokkos, openmpi, nlohmann_json, gtest
+}:
+
+stdenv.mkDerivation {
+  pname = "exaca";
+  inherit version src;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    kokkos
+    nlohmann_json
+    gtest
+  ];
+
+  propagatedBuildInputs = [
+    openmpi
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "ExaCA_REQUIRE_EXTERNAL_JSON" true)
+    (lib.cmakeBool "ExaCA_ENABLE_TESTING" false)
+  ];
+}


### PR DESCRIPTION
Hey here's that PR I mentioned.

2 major things:
- callPackage usage like we did for adamantine
- Use flake-parts over flake-utils

Another thing I think worth mentioning is I'm not sure if having a stable attribute is the right way to go. From what I understand, the intention from upstream Nix right now is to rely on the tags in a given repo. So kinda like how we use `nixpkgs` where we say we want `NixOS/nixpkgs/25.05`. I think we should mirror that pattern here if that's alright with you. That way, we don't accidentally build the wrong source with the wrong drv in the future.

Feel free to make any changes you want!